### PR TITLE
refactor: Replacing `atomic` `-covermode` with `set`

### DIFF
--- a/src/cover/coverage.go
+++ b/src/cover/coverage.go
@@ -57,7 +57,7 @@ func runTests(path, target string, dependencies []dependency) ([]Coverage, error
 		"go", "test",
 		"-run", target,
 		"-coverprofile="+coverageFile.Name(),
-		"-covermode=atomic",
+		"-covermode=set",
 		"-coverpkg="+strings.Join(packages, ","),
 		path,
 	)


### PR DESCRIPTION
## Description
Replacing the computationally expensive `-covermode=atomic` with the cheaper `-covermode=set` given we only care about coverage not the number of statement executions.